### PR TITLE
adding metadata to header

### DIFF
--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -1,14 +1,23 @@
 <head>
-  <meta charset="UTF-8">
-  <title>{{ site.title }}</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-  <link rel="stylesheet" href="{{ site.baseurl }}/css/normalize.css">
-  <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Source+Sans+Pro:300,300i,600">
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-  <script src="{{ site.baseurl }}/js/jquery.dlmenu.js"></script>
-  <script src="{{ site.baseurl }}/js/modernizr.custom.js"></script>
-  <link href="{{ site.baseurl }}/css/bootstrap.min.css" rel="stylesheet" />
-  <link href="{{ site.baseurl }}/css/fresh-bootstrap-table.css" rel="stylesheet" />
+    <meta charset="UTF-8">
+    <title>{{ site.title }}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+    <link rel="stylesheet" href="{{ site.baseurl }}/css/normalize.css">
+    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Source+Sans+Pro:300,300i,600">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+    <script src="{{ site.baseurl }}/js/jquery.dlmenu.js"></script>
+    <script src="{{ site.baseurl }}/js/modernizr.custom.js"></script>
+    <link href="{{ site.baseurl }}/css/bootstrap.min.css" rel="stylesheet" />
+    <link href="{{ site.baseurl }}/css/fresh-bootstrap-table.css" rel="stylesheet" />
+    <meta name="description" content="Experiment Factory: Reproducible Container Experiments">
+    <meta name="thumbnail" content="https://expfactory.github.io{{ site.baseurl }}/img/expfactoryticketyellow.png">
+    {% if page.name %}<meta name="name" content="{{ page.name }}">{% endif %}
+    {% if page.tags %}<meta name="tags" content="{% for tag in page.tags %}{{ tag }} {% if forloop.last %}{% else %},{% endif %}{% endfor %}">{% endif %}
+    {% if page.maintainer %}<meta name="author" content="{{ page.maintainer }}">{% endif %}
+    {% if page.preview %}<meta name="preview" content="{{ page.preview }}">{% endif %}
+    {% if page.github %}<meta name="repository" content="{{ page.github }}">
+    <meta name="file" content="{{ page.github }}/archive/master.zip"> 
+    <meta name="pagetype" content="experiment">{% endif %}
 </head>

--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -14,7 +14,7 @@
     <meta name="description" content="Experiment Factory: Reproducible Container Experiments">
     <meta name="thumbnail" content="https://expfactory.github.io{{ site.baseurl }}/img/expfactoryticketyellow.png">
     {% if page.name %}<meta name="name" content="{{ page.name }}">{% endif %}
-    {% if page.tags %}<meta name="tags" content="{% for tag in page.tags %}{{ tag }} {% if forloop.last %}{% else %},{% endif %}{% endfor %}">{% endif %}
+    {% if page.tags %}<meta name="tags" content="{% for tag in page.tags %}{{ tag }}{% if forloop.last %}{% else %},{% endif %}{% endfor %}">{% endif %}
     {% if page.maintainer %}<meta name="author" content="{{ page.maintainer }}">{% endif %}
     {% if page.preview %}<meta name="preview" content="{{ page.preview }}">{% endif %}
     {% if page.github %}<meta name="repository" content="{{ page.github }}">


### PR DESCRIPTION
This will add simple metadata flags to the html head to give easy access to:

 - tags
 - name
 - description
 - author
 - github
 - thumbnail

and will close #24 . This is important for robots to find and index, making the experiment more visible. An example is the following:

```
<head>
    <meta charset="UTF-8">
    <title>The Experiment Factory</title>
    <meta name="viewport" content="width=device-width, initial-scale=1">
    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />

...

    <meta name="description" content="Experiment Factory: Reproducible Container Experiments">
    <meta name="thumbnail" content="https://expfactory.github.io/experiments/img/expfactoryticketyellow.png">
    <meta name="name" content="adaptive-n-back">
    <meta name="tags" content="jspsych ,experiment ">
    <meta name="author" content="@vsoch">
    <meta name="preview" content="https://expfactory-experiments.github.io/adaptive-n-back">
    <meta name="repository" content="https://www.github.com/expfactory-experiments/adaptive-n-back">
    <meta name="file" content="https://www.github.com/expfactory-experiments/adaptive-n-back/archive/master.zip"> 
    <meta name="pagetype" content="experiment">
</head>
```